### PR TITLE
Add a landing page

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,4 @@
 .Ruserdata
 .Renviron
 .httr-oauth
+.DS_Store

--- a/R/deploy.R
+++ b/R/deploy.R
@@ -7,10 +7,21 @@ plumberDeploy::do_deploy_api(
   path = "TidyTuesday",
   localPath = ".",
   port = 8002,
-  docs = TRUE
+  forward = TRUE,
+  overwrite = TRUE
 )
 
-# NOTE:
-#  .Renviron doesn't deploy (i think because it starts with a '.'?)
+# NOTES:
+# 1. .Renviron doesn't deploy (i think because it starts with a '.'?)
 #  so need to add it at var/plumber/TidyTuesday
 #  then reboot with 'sudo reboot now' for changes to take affect
+# 2. plumber has a bug where if serving static files at /, docs give a 404
+#  so for now, set docs=FALSE (default). later, can add if desired
+#  see plumber PR #748
+# 3. forward=TRUE points requests for / to /TidyTuesday, where this project
+#  lives. didn't have that at first. so this is a reminder of why
+#  see https://community.rstudio.com/t/what-does-plumberdeploy-do-forward-do/107304
+# 4. see ?plumberDeploy::do_provision() Details for how to
+#  a. restart plumber: systemctl restart plumber-TidyTuesday
+#  b. see plumber logs: journalctl -u plumber-TidyTuesday
+#     logs from last 5 minutes: journalctl -u plumber-TidyTuesday -S -5m

--- a/plumber.R
+++ b/plumber.R
@@ -3,8 +3,12 @@ library(mongolite)
 library(jsonlite)
 
 #* @apiTitle Tidy Tuesday API
-#* @apiDescription This is an API to access data sets from the Tidy Tuesday project. You can find out more about Tidy Tuesday [here](https://github.com/rfordatascience/tidytuesday).
-#* @apiVersion 0.0.0.9000
+#* @apiDescription This is an API to access data sets from the Tidy Tuesday project. For more information about this API, see the [project GitHub](https://github.com/asbates/tidytuesdayapi). You can find out more about Tidy Tuesday on it's [home page](https://github.com/rfordatascience/tidytuesday).
+#* @apiVersion 0.0.1
+
+# serves the landing page
+#* @assets ./static /
+list()
 
 #* Get information about available data sets, like date and description.
 #* @param limit Limit the number of results to return.

--- a/static/index.html
+++ b/static/index.html
@@ -1,0 +1,31 @@
+<!DOCTYPE html>
+<html>
+    <head>
+        <meta charset="utf-8">
+        <title>Tidy Tuesday API</title>
+        <style>
+            @import url('https://fonts.googleapis.com/css2?family=Poppins&display=swap');
+
+            body {
+                font-family: 'Poppins', sans-serif;
+                background-color: #F5F5F5;
+            }
+
+            h1, p {
+                text-align: center;
+            }
+        </style>
+    </head>
+    <body>
+        <h1>Welcome!</h1>
+        <p>
+            Welcome to the Tidy Tuesday web API!
+            This is an API to access data sets from the Tidy Tuesday project.
+            Why we welcome you here, <strong>this is probably not what you are looking for.</strong>
+        </p>
+        <p>
+            For details about this API, see <a href="https://github.com/asbates/tidytuesdayapi">the project readme.</a>
+            For more information about Tidy Tuesday, check out the <a href="https://github.com/rfordatascience/tidytuesday">project page.</a>
+        </p>
+    </body>
+</html>


### PR DESCRIPTION
Adds a landing page at root url.

Notes for future self:

When serving static files at '/', the docs endpoint doesn't work (returns 404). This is being resolved by the plumber team (https://github.com/rstudio/plumber/pull/748). For now, I just don't add docs.

On initial deployment, I was able to access landing page and '/available'. But '/data' wasn't working. After figuring out how to access the plumber logs I was getting the error `<simpleError: user is not allowed to do action [createIndex] on [data.fs.chunks]>`. This is an issue with the underlying C library for mongolite. See https://github.com/jeroen/mongolite/issues/190. I was able to resolve this by setting the server account to allow both read and write access to the MongoDB database. Before, it was read only.